### PR TITLE
Handle two finger zoom and double click behavior

### DIFF
--- a/app/src/main/java/nl/flitsmeister/maplibrecar/MainActivity.kt
+++ b/app/src/main/java/nl/flitsmeister/maplibrecar/MainActivity.kt
@@ -10,21 +10,21 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
-import com.mapbox.mapboxsdk.Mapbox
-import com.mapbox.mapboxsdk.camera.CameraPosition
-import com.mapbox.mapboxsdk.geometry.LatLng
-import com.mapbox.mapboxsdk.maps.MapView
-import com.mapbox.mapboxsdk.maps.MapboxMap
-import com.mapbox.mapboxsdk.maps.MapboxMapOptions
-import com.mapbox.mapboxsdk.maps.Style
 import nl.flitsmeister.car_common.R
 import nl.flitsmeister.car_common.ResourceUtils
 import nl.flitsmeister.maplibrecar.ui.theme.MapLibreCarTheme
+import org.maplibre.android.MapLibre
+import org.maplibre.android.camera.CameraPosition
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapLibreMapOptions
+import org.maplibre.android.maps.MapView
+import org.maplibre.android.maps.Style
 
 class MainActivity : ComponentActivity() {
 
     var mapView: MapView? = null
-    var mapBoxMap: MapboxMap? = null
+    var mapLibreMap: MapLibreMap? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -34,7 +34,7 @@ class MainActivity : ComponentActivity() {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                     AndroidView(modifier = Modifier.padding(innerPadding), factory = { context ->
                         //TextView(context).apply { setText("Hello MapLibreCar") }
-                        val mapboxOptions = MapboxMapOptions.createFromAttributes(context).apply {
+                        val mapLibreMapOptions = MapLibreMapOptions.createFromAttributes(context).apply {
                             textureMode(true)
                             camera(
                                 CameraPosition.Builder()
@@ -43,11 +43,11 @@ class MainActivity : ComponentActivity() {
                                     .build()
                             )
                         }
-                        Mapbox.getInstance(context)
-                        mapView = MapView(context, mapboxOptions)
+                        MapLibre.getInstance(context)
+                        mapView = MapView(context, mapLibreMapOptions)
                         mapView?.onCreate(savedInstanceState)
                         mapView?.getMapAsync {
-                            mapBoxMap = it
+                            mapLibreMap = it
                             initMap(it)
                         }
                         mapView!!
@@ -57,7 +57,7 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private fun initMap(map: MapboxMap) {
+    private fun initMap(map: MapLibreMap) {
         try {
             map.setStyle(
                 //TODO: Set your own style here!

--- a/car_common/src/main/java/nl/flitsmeister/car_common/CarMapContainer.kt
+++ b/car_common/src/main/java/nl/flitsmeister/car_common/CarMapContainer.kt
@@ -9,13 +9,13 @@ import androidx.car.app.CarContext
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
-import com.mapbox.mapboxsdk.Mapbox
-import com.mapbox.mapboxsdk.maps.MapView
-import com.mapbox.mapboxsdk.maps.MapboxMap
-import com.mapbox.mapboxsdk.maps.MapboxMapOptions
-import com.mapbox.mapboxsdk.maps.Style
 import nl.flitsmeister.car_common.extentions.runOnMainThread
 import nl.flitsmeister.car_common.extentions.windowManager
+import org.maplibre.android.MapLibre
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapLibreMapOptions
+import org.maplibre.android.maps.MapView
+import org.maplibre.android.maps.Style
 
 class CarMapContainer(
     private val carContext: CarContext, lifecycle: Lifecycle
@@ -28,13 +28,13 @@ class CarMapContainer(
     var mapViewInstance: MapView? = null
         private set
 
-    var mapboxMapInstance: MapboxMap? = null
+    var mapLibreMapInstance: MapLibreMap? = null
 
     var surfaceWidth: Int? = null
     var surfaceHeight: Int? = null
 
     fun scrollBy(x: Float, y: Float) {
-        mapboxMapInstance?.scrollBy(-x, -y, 0  )
+        mapLibreMapInstance?.scrollBy(-x, -y, 0  )
     }
     
     /**
@@ -52,7 +52,7 @@ class CarMapContainer(
     }
 
     override fun onCreate(owner: LifecycleOwner) {
-        Mapbox.getInstance(carContext)
+        MapLibre.getInstance(carContext)
 
         runOnMainThread {
             mapViewInstance = createMapViewInstance().apply {
@@ -65,7 +65,7 @@ class CarMapContainer(
                 onStart()
                 getMapAsync {
                     mapViewInstance = this
-                    mapboxMapInstance = it
+                    mapLibreMapInstance = it
                     it.setStyle(
                         //TODO: Set your own style here
                         Style.Builder().fromJson(ResourceUtils.readRawResource(carContext, R.raw.local_style))
@@ -85,7 +85,7 @@ class CarMapContainer(
 
     override fun onDestroy(owner: LifecycleOwner) {
         runOnMainThread {
-            mapboxMapInstance = null
+            mapLibreMapInstance = null
 
             mapViewInstance?.run {
                 onStop()
@@ -97,7 +97,7 @@ class CarMapContainer(
     }
 
     private fun createMapViewInstance() =
-        MapView(carContext, MapboxMapOptions.createFromAttributes(carContext).apply {
+        MapView(carContext, MapLibreMapOptions.createFromAttributes(carContext).apply {
             // Set the textureMode to true, so a TextureView is created
             // We can extract this TextureView to draw on the Android Auto surface
             textureMode(true)

--- a/car_common/src/main/java/nl/flitsmeister/car_common/CarMapContainer.kt
+++ b/car_common/src/main/java/nl/flitsmeister/car_common/CarMapContainer.kt
@@ -76,7 +76,7 @@ class CarMapContainer(
                 1.0,
                 zoomFocalPoint
             )
-            scaleAnimator!!.start()
+            scaleAnimator?.start()
         }
     }
 

--- a/car_common/src/main/java/nl/flitsmeister/car_common/CarMapRenderer.kt
+++ b/car_common/src/main/java/nl/flitsmeister/car_common/CarMapRenderer.kt
@@ -17,9 +17,9 @@ import androidx.car.app.SurfaceContainer
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
-import com.mapbox.mapboxsdk.maps.MapView
 import nl.flitsmeister.car_common.extentions.appManager
 import nl.flitsmeister.car_common.extentions.runOnMainThread
+import org.maplibre.android.maps.MapView
 
 class CarMapRenderer(
     private val carContext: CarContext,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ composeBom = "2024.10.01"
 appcompat = "1.7.0"
 material = "1.12.0"
 carApp = "1.4.0"
-mapLibreSdk = "10.2.0"
+mapLibreSdk = "11.7.0"
 mapLibreNav = "3.0.0"
 
 [libraries]


### PR DESCRIPTION
This pull request includes significant changes to migrate from Mapbox to MapLibre and introduces new functionality for map interaction. The most important changes are grouped by theme as follows:

Migration from Mapbox to MapLibre:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-R49): Updated code examples to use `MapLibreMapOptions` and `MapLibreMap` instead of `MapboxMapOptions` and `MapboxMap`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-R49) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L126-R125) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L135-R134)
* [`app/src/main/java/nl/flitsmeister/maplibrecar/MainActivity.kt`](diffhunk://#diff-81243589811e7608ab34f1aa816f09a84b7cbdab4f2cf91032aee8cb28990a80L13-R27): Replaced Mapbox imports and instances with MapLibre equivalents. [[1]](diffhunk://#diff-81243589811e7608ab34f1aa816f09a84b7cbdab4f2cf91032aee8cb28990a80L13-R27) [[2]](diffhunk://#diff-81243589811e7608ab34f1aa816f09a84b7cbdab4f2cf91032aee8cb28990a80L37-R37) [[3]](diffhunk://#diff-81243589811e7608ab34f1aa816f09a84b7cbdab4f2cf91032aee8cb28990a80L46-R50) [[4]](diffhunk://#diff-81243589811e7608ab34f1aa816f09a84b7cbdab4f2cf91032aee8cb28990a80L60-R60)
* [`car_common/src/main/java/nl/flitsmeister/car_common/CarMapContainer.kt`](diffhunk://#diff-e9c91cc61afecdf8cb57859c758ef10259291a50648d24be55c2dacbccf1e612R3-R24): Replaced Mapbox imports and instances with MapLibre equivalents. [[1]](diffhunk://#diff-e9c91cc61afecdf8cb57859c758ef10259291a50648d24be55c2dacbccf1e612R3-R24) [[2]](diffhunk://#diff-e9c91cc61afecdf8cb57859c758ef10259291a50648d24be55c2dacbccf1e612L31-R104) [[3]](diffhunk://#diff-e9c91cc61afecdf8cb57859c758ef10259291a50648d24be55c2dacbccf1e612L55-R122) [[4]](diffhunk://#diff-e9c91cc61afecdf8cb57859c758ef10259291a50648d24be55c2dacbccf1e612L68-R139) [[5]](diffhunk://#diff-e9c91cc61afecdf8cb57859c758ef10259291a50648d24be55c2dacbccf1e612L88-R156) [[6]](diffhunk://#diff-e9c91cc61afecdf8cb57859c758ef10259291a50648d24be55c2dacbccf1e612L100-R168) [[7]](diffhunk://#diff-e9c91cc61afecdf8cb57859c758ef10259291a50648d24be55c2dacbccf1e612R179)
* [`car_common/src/main/java/nl/flitsmeister/car_common/CarMapRenderer.kt`](diffhunk://#diff-52e2d1570a5988cff256b2fb02f8251fa5896968383174bdfc89a716bead6624L20-R22): Replaced Mapbox imports with MapLibre equivalents.

New functionality for map interaction:

* [`car_common/src/main/java/nl/flitsmeister/car_common/CarMapContainer.kt`](diffhunk://#diff-e9c91cc61afecdf8cb57859c758ef10259291a50648d24be55c2dacbccf1e612L31-R104): Added new methods for handling map scaling and double-click zoom with animation. [[1]](diffhunk://#diff-e9c91cc61afecdf8cb57859c758ef10259291a50648d24be55c2dacbccf1e612L31-R104) [[2]](diffhunk://#diff-e9c91cc61afecdf8cb57859c758ef10259291a50648d24be55c2dacbccf1e612L55-R122)
* [`car_common/src/main/java/nl/flitsmeister/car_common/CarMapRenderer.kt`](diffhunk://#diff-52e2d1570a5988cff256b2fb02f8251fa5896968383174bdfc89a716bead6624L154-R155): Simplified the `onScale` method by delegating to `CarMapContainer` and removed the custom zoom gesture generation. [[1]](diffhunk://#diff-52e2d1570a5988cff256b2fb02f8251fa5896968383174bdfc89a716bead6624L154-R155) [[2]](diffhunk://#diff-52e2d1570a5988cff256b2fb02f8251fa5896968383174bdfc89a716bead6624L190-L324)

Library version updates:

* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL14-R14): Updated `mapLibreSdk` version from `10.2.0` to `11.7.0`.

Update contributor recogization
